### PR TITLE
build: add Clippy as a pre-push hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,5 @@
+pre-push:
+  commands:
+    clippy:
+      glob: "*.rs"
+      run: cargo clippy -- -D warnings


### PR DESCRIPTION
It's set up to run this check in CI, but that feedback loop is a lot shorter if it runs locally first.